### PR TITLE
Move the rebase episode to be optional

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,8 +67,8 @@ episodes:
 - 05-forks.md
 - 06-conflict.md
 - 07-history.md
-- 08-rebase.md
 - End.md
+- 08-rebase.md
 - 09-pre-commit.md
 
 # Information for Learners

--- a/episodes/07-history.md
+++ b/episodes/07-history.md
@@ -268,9 +268,6 @@ a commit that introduced a bug.
 
 Your team will decide what approach is right
 for your project.
-If you choose to perform normal merge's on
-your PRs we recommend rebasing your feature branch
-before the PR is ready for review.
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/08-rebase.md
+++ b/episodes/08-rebase.md
@@ -1,5 +1,5 @@
 ---
-title: Rebasing
+title: 'Rebasing'
 teaching: 15
 exercises: 10
 ---

--- a/episodes/09-pre-commit.md
+++ b/episodes/09-pre-commit.md
@@ -1,5 +1,5 @@
 ---
-title: 'Optional: Pre-commit'
+title: 'Pre-commit'
 teaching: 10
 exercises: 10
 ---

--- a/episodes/End.md
+++ b/episodes/End.md
@@ -9,6 +9,12 @@ Please remember to fill out your post-workshop feedback.
 This feedback is vital for us to keep improving the lesson
 for other learners.
 
+Episodes after this **End** page are optional.
+Your instructor may choose to teach these episodes
+if time permits.
+Otherwise feel free to work through the episodes
+in your own time.
+
 ### Where to next?
 
 We've covered a lot over the last two workshops
@@ -19,5 +25,6 @@ when it comes to GitHub!
   GitHub training.
 - In this lesson you saw automated testing
   of PRs using [GitHub Actions](https://learn.microsoft.com/en-us/training/modules/introduction-to-github-actions/) which you might like to explore more.
-- These tests ran [pre-commit](https://pre-commit.com/) checks which you can set up locally to run before you commit.
+- The optional [rebasing episode](./08-rebase.md) guides you through rebasing a branch.
+- These PR tests ran [pre-commit](https://pre-commit.com/) checks which you can set up locally to run before you commit.
   The optional [pre-commit episode](./09-pre-commit.md) outlines how to set up some basic checks.


### PR DESCRIPTION
Closes #16 

Remove the opinionated line about rebasing after merging. Clarify that episodes after the end card are optional so that they don't have to have optional in the title of the episode.