### PR TITLE
Add node diagrams of where different bits of data are.

### DIFF
--- a/episodes/02-branching.md
+++ b/episodes/02-branching.md
@@ -133,6 +133,20 @@ config:
         merge large_feature
 ```
 
+An alternative way of viewing this workflow is:
+
+```mermaid
+graph TD
+    main --> |switch/checkout| lfb["feature branch"]
+    lfb --> |push| rfb["feature branch"]
+    subgraph github
+        rfb --> |"pull request (PR)"| main
+    end
+    subgraph local["my computer"]
+        lfb
+    end
+```
+
 -----------------------------------------
 
 ### Forking
@@ -142,6 +156,26 @@ to contribute to on GitHub in your personal space.
 You develop your changes using this fork.
 When a change is ready you open a pull request to contribute the changes
 back to the original repository.
+
+```mermaid
+graph BT
+    subgraph local["my computer"]
+        lfb
+    end
+    subgraph github
+        subgraph "my fork"
+            rfb
+            mm["my copy of main"]
+        end
+        rfb --> |"pull request (PR)"| main
+        main --> |"sync"| mm
+        subgraph upstream
+            main
+        end
+    end
+    mm --> |switch/checkout| lfb["feature branch"]
+    lfb --> |push| rfb["feature branch"]
+```
 
 #### Pros
 
@@ -208,6 +242,35 @@ merged onto the `develop` and `main` branches.
         merge release tag:"1.0"
         checkout develop
         merge release
+```
+
+Or, alternatively:
+
+```mermaid
+graph BT
+    subgraph local["my computer"]
+        lfb
+        lbfb
+    end
+    subgraph github
+        subgraph "my fork"
+            md["my copy of develop"]
+            rfb
+            rbfb
+            mm["my copy of main"]
+        end
+        rfb --> |"pull request (PR)"| develop
+        rbfb --> |"pull request (PR)"| main
+        develop --> |"sync"| md
+        main --> |"sync"| mm
+        subgraph upstream
+            develop <--> |sync| main
+        end
+    end
+    md --> |switch/checkout| lfb["feature branch"]
+    lbfb --> |push| rbfb["bugfix branch"]
+    lfb --> |push| rfb["feature branch"]
+    mm --> |switch/checkout| lbfb["bugfix branch"]
 ```
 
 ## Recommendations


### PR DESCRIPTION
This adds what I believe are helpful node diagrams of two of the forking models, and a less helpful diagram of the third (which is nonetheless illustrative).

See https://github.com/wxtim/git-working-practices/blob/node-diagrams_of_branch_modes/episodes/02-branching.md for the preview.

@astroDimitrios I've tried to build the docs locally, but the instructions seem to assume that I can `sudo apt install`. How do you preview changes when reviewing?